### PR TITLE
Fixed minor problems with argument matching

### DIFF
--- a/R/get.CI.R
+++ b/R/get.CI.R
@@ -16,10 +16,10 @@ bootdat <- replicate(bootstraps, one.boot(time, event, model1,
                                   method,
                                   bw.power))
 #lower bounds
-
-bootdat.NRI.event    <- bootdat[,1,]
-bootdat.NRI.nonevent <- bootdat[,2,]
-bootdat.NRI          <- bootdat[,3,]  
+#If only one method is used this need to stay matrices
+bootdat.NRI.event    <- bootdat[,1,,drop=F]
+bootdat.NRI.nonevent <- bootdat[,2,,drop=F]
+bootdat.NRI          <- bootdat[,3,,drop=F]  
 
 if(bootMethod == "percentile"){
 

--- a/R/survNRI.R
+++ b/R/survNRI.R
@@ -1,62 +1,55 @@
 survNRI <-
-function(time, event, model1, model2, data,  predict.time, 
-                method ="all",  bw.power = 0.35,  bootMethod = "normal",bootstraps = 500, alpha = 0.05
-){
+    function(time, event, model1, model2, data,  predict.time, 
+             method = c("KM","IPW", "SmoothIPW",  "SEM", "Combined","all"),  bw.power = 0.35,  bootMethod = c("normal","percentile","none"),bootstraps = 500, alpha = 0.05
+             ){
 
-if(!is.element(time, names(data))) stop("'time' variable not recognized")
-if(!is.element(event, names(data))) stop("'event' variable not recognized")
-if(!all(is.element(model1, names(data)))) stop("'model1' variable names not recognized")
-if(!all(is.element(model2, names(data)))) stop("'model2' variable names not recognized")
-if(!is.element(bootMethod, c("normal", "percentile"))) stop("bootMethod must be either 'normal', 'percentile' or 'none'")
+        if(!is.element(time, names(data))) stop("'time' variable not recognized")
+        if(!is.element(event, names(data))) stop("'event' variable not recognized")
+        if(!all(is.element(model1, names(data)))) stop("'model1' variable names not recognized")
+        if(!all(is.element(model2, names(data)))) stop("'model2' variable names not recognized")
+        bootMethod <- match.arg(bootMethod)
 
-
-tmpdat <- data[,-which(c(time, event)==names(data)) ]
-
-
-time = data[,time]
-event= data[,event]
-
-data <- tmpdat
-
-method = c(method)
-if( !all(is.element(method, c("IPW", "KM", "SEM", "SmoothIPW", "Combined", "all")))){
-
-   tmpind <- which(!is.element(method,  c("KM", "IPW", "SmoothIPW", "SEM", "Combined", "all")))
-   
-   stop(paste( "Unknown method '", method[tmpind], "' \n 'method' must be a vector subset of c('IPW', 'KM', 'SEM', 'SmoothIPW', 'Combined', 'all')", sep = ""))
-} 
-
-  if(any(is.element(method, "all"))) method = c("KM","IPW", "SmoothIPW",  "SEM", "Combined")
-  method <- c(method)
-  
-  result <- get.estimates( time = time, event = event, model1 = model1,
-                                                       model2 = model2,
-                                                       data = data,
-                                                       predict.time = predict.time,
-                                                       method =method,
-                                                       bw.power = bw.power)
-
-  if(bootMethod != "none"){
-
-  if(bootstraps < 2) stop("bootstraps must be greater than 2 to compute CI's")
-
-  ci <- get.CI(  time = time, event = event, model1 = model1,
-                                                       model2 = model2,
-                                                       data = data,
-                                                       predict.time = predict.time,
-                                                       method =method,
-                                                       bw.power = bw.power, 
-                                                       bootMethod = bootMethod, 
-                                                       bootstraps = bootstraps,
-                                                       alpha = alpha) 
-  }else{
-  ci<- NULL
-  } 
-
-  out <- list("estimates" = result, "CI" = ci, "bootMethod" = bootMethod, "predict.time" = predict.time, "alpha" = alpha)
-  class(out) = "survNRI"
-
-  return(out)
+        tmpdat <- data[,-which(c(time, event)==names(data)) ]
 
 
- }
+        time = data[,time]
+        event= data[,event]
+
+        data <- tmpdat
+
+        method <- match.arg(method,several.ok=T)
+
+        ## set methods to all if explicitely asked for 
+        if(any(is.element(method, "all"))) method = c("KM","IPW", "SmoothIPW",  "SEM", "Combined")
+        
+        result <- get.estimates( time = time, event = event, model1 = model1,
+                                model2 = model2,
+                                data = data,
+                                predict.time = predict.time,
+                                method =method,
+                                bw.power = bw.power)
+
+        if(bootMethod != "none"){
+
+            if(bootstraps < 2) stop("bootstraps must be greater than 2 to compute CI's")
+
+            ci <- get.CI(  time = time, event = event, model1 = model1,
+                         model2 = model2,
+                         data = data,
+                         predict.time = predict.time,
+                         method =method,
+                         bw.power = bw.power, 
+                         bootMethod = bootMethod, 
+                         bootstraps = bootstraps,
+                         alpha = alpha) 
+        }else{
+            ci<- NULL
+        } 
+
+        out <- list("estimates" = result, "CI" = ci, "bootMethod" = bootMethod, "predict.time" = predict.time, "alpha" = alpha)
+        class(out) = "survNRI"
+
+        return(out)
+
+
+    }


### PR DESCRIPTION
Hi,
in your version of the package bootMethod="none" was not working as it didn't appear as an option. I have taken the liberty to change the argument matching in survNRI to R's internal function for that (match.arg). A small disadvantage is that if method now is a vector including some unsupported (or misspelled) options, then no error message is printed but only the correct options are used. This could be fixed very easily if desired.

Best regards,
Florian Klinglmueller
